### PR TITLE
correction in HLT string name for 2017 data

### DIFF
--- a/Onia/python/MixingRootupler_cfi.py
+++ b/Onia/python/MixingRootupler_cfi.py
@@ -19,7 +19,7 @@ rootuple = cms.EDAnalyzer('MixingRootupler',
  				    #'HLT_Trimuon5_3p5_2_Upsilon_Muon_v',       #2018  HLT string
                                     #'HLT_TrimuonOpen_5_3p5_2_Upsilon_Muon_v',  #2018 HLT string
                                     'HLT_Trimuon2_Upsilon5_Muon_v',            #2017B HLT string
-                                    'HLT_Trimuon5_3p5_2_Upsilon_Muon_v',       #2017C, D, E and F HLT string
+                                    #'HLT_Trimuon5_3p5_2_Upsilon_Muon_v',       #2017C, D, E and F HLT string
                                     #'HLT_Dimuon0_Upsilon_Muon_v',             #2016 HLT string 
                                     #'HLT_Dimuon0_Phi_Barrel_v',               #2016 HLT string 
                                     #'HLT_Dimuon13_Upsilon_v',                 #2016 HLT string 

--- a/Onia/python/MixingRootupler_cfi.py
+++ b/Onia/python/MixingRootupler_cfi.py
@@ -18,7 +18,8 @@ rootuple = cms.EDAnalyzer('MixingRootupler',
     triggerList = cms.untracked.vstring(
  				    #'HLT_Trimuon5_3p5_2_Upsilon_Muon_v',       #2018  HLT string
                                     #'HLT_TrimuonOpen_5_3p5_2_Upsilon_Muon_v',  #2018 HLT string
-                                    'HLT_Trimuon2_Upsilon5_Muon_v',            #2017 HLT string
+                                    'HLT_Trimuon2_Upsilon5_Muon_v',            #2017B HLT string
+                                    'HLT_Trimuon5_3p5_2_Upsilon_Muon_v',       #2017C, D, E and F HLT string
                                     #'HLT_Dimuon0_Upsilon_Muon_v',             #2016 HLT string 
                                     #'HLT_Dimuon0_Phi_Barrel_v',               #2016 HLT string 
                                     #'HLT_Dimuon13_Upsilon_v',                 #2016 HLT string 


### PR DESCRIPTION
This is correction as compared to an earlier pull request at [1]. Candan complained that distributions are empty in 2017 samples (except RunB). I followed this and found that the HLT trigger names is different in 2017B and other eras of 2017. So i have added this in config file.  

[1] https://github.com/zhenhu/DatasetsMixing/pull/3